### PR TITLE
Add IPv6 support and make hostname resolution more robust

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,16 +3,13 @@
 # nlbw2collectd
 This collectd lua plugin allows you to put [Nlbwmon](https://github.com/jow-/nlbwmon) statistics directly to Collectd (luci-app-statistics). By default on Openwrt statistics are uploaded every 30 seconds, so it allows you to get pseudo realtime statistic about the traffic on your router.
 
-# Why this plugin has been  created
+# Why this plugin has been created
 I have been using [Iptmon](https://github.com/oofnikj/iptmon) tool to get very nice statistics of per host traffic on my Openwrt router. Unfortunatelly starting from Openwrt 22.03 release [Iptmon](https://github.com/oofnikj/iptmon) stopped to work due to replacement of iptables with nftables. When looking for alternatives I was not able to find anything what was close to Iptmon and working on latest Openwrt releases. I found [Nlbwmon](https://github.com/jow-/nlbwmon) to be very nice tool but what I was missing was more detailed per hour statistics with nice charts.
 
 # Dependencies
-This plugin assumes that you have Luci and luci-app-statistics installed. This plugin uses luci.jsonc lua library that should be bundled with Luci, if that is not the case you need to install this (details below). 
-Another required library is collectd-mod-lua
+This plugin assumes that you have Luci and luci-app-statistics installed. This plugin uses the `luci.jsonc` and `luci.ip` lua libraries that should be bundled with Luci, if that is not the case you need to install this (details below).
+Another required library is collectd-mod-lua.
 
-# Limitation
-Currently only IPv4 is supported, IPv6 support can be added later.
- 
 # Installation instructions.
 1. Make sure that you have `collectd-mod-lua` installed on you openwrt router if not execute:
    ```
@@ -20,29 +17,30 @@ Currently only IPv4 is supported, IPv6 support can be added later.
    opkg install collectd-mod-lua
    ```
 
-2. Make sure that `luci-lib-jsonc` is installed:
-   ```
-   opkg list-installed | grep luci-lib-jsonc
+2. Make sure that `luci-lib-jsonc` and `luci-lib-ip` are installed:
+   ```console
+   # opkg list-installed | grep -E 'luci-lib-jsonc|luci-lib-ip'
    [...]
-   luci-lib-jsonc - git-22.097.61937-bc85ba5
+   luci-lib-ip - 25.163.46283~ec8edb4
+   luci-lib-jsonc - 25.163.46283~ec8edb4
    ```
    If it is not installed install this with:
+   ```console
+   # opkg install luci-lib-jsonc luci-lib-ip
    ```
-   opkg install luci-lib-jsonc
-   ```
-   
+
 3. Copy [lua.conf](lua.conf) to `collectd config` directory
+   ```console
+   # cp lua.conf /etc/collectd/conf.d
    ```
-   cp lua.conf /etc/collectd/conf.d
-   ```
-   
+
 4. Copy [nlbw2collectd.lua](nlbw2collectd.lua) to `/usr/share/collectd-mod-lua/` directory
-   ```
-   cp nlbw2collectd.lua /usr/share/collectd-mod-lua/
+   ```console
+   # cp nlbw2collectd.lua /usr/share/collectd-mod-lua/
    ```
 5. Restart collectd
-   ```
-   /etc/init.d/collectd  restart
+   ```console
+   # /etc/init.d/collectd  restart
    ```
 6. Login to Luci and go to Statistics->Graphs->Firewall. After about minute you should see your statistics.
 
@@ -59,7 +57,7 @@ local PLUGIN_INSTANCE_RX="mangle-iptmon_rx" -- we have full compliance with iptm
 local PLUGIN_INSTANCE_TX="mangle-iptmon_tx" -- we have full compliance with iptmon
 ```
 
-Make sure that Iptmon is not installed since this plugin and Iptmon can not coexist. 
+Make sure that Iptmon is not installed since this plugin and Iptmon can not coexist.
 
 # Example pictures
 
@@ -75,6 +73,3 @@ By exporting data to external Influxdb/Grafana server you can get more pleasant 
 ![Grafana TX chart](graphics/Grafana_Nlbwmon_tx_chart.jpg)
 ![Grafana RX Total](graphics/Grafana_Nlbwmon_rx.jpg)
 ![Grafana TX Total](graphics/Grafana_Nlbwmon_tx.jpg)
-
-   
-   

--- a/nlbw2collectd.lua
+++ b/nlbw2collectd.lua
@@ -1,135 +1,164 @@
-require "luci.jsonc"
---require "luci.sys"
---require "luci.util"
-local io = require "io"
+-- Configuration options:
+local HOSTNAME = "" -- leave empty if you track statistics for local system, change when you really know that you want different hostname to be used
+local PLUGIN = "iptables"
+local PLUGIN_INSTANCE_RX = "mangle-nlbwmon_rx" -- change to "mangle-iptmon_rx" to have full compliance with iptmon
+local PLUGIN_INSTANCE_TX = "mangle-nlbwmon_tx" -- change to "mangle-iptmon_tx" to have full compliance with iptmon
+local TYPE_BYTES = "ipt_bytes"
+local TYPE_PACKETS = "ipt_packets"
+local TYPE_INSTANCE_PREFIX_RX = "rx_"
+local TYPE_INSTANCE_PREFIX_TX = "tx_"
+-- End of configuration options
 
-local HOSTNAME = '' -- leave empty if you track statistics for local system, change when you really know that you want different hostname to be used
-local PLUGIN="iptables"
-local PLUGIN_INSTANCE_RX="mangle-nlbwmon_rx" -- change to "mangle-iptmon_rx" to have full compliance with iptmon
-local PLUGIN_INSTANCE_TX="mangle-nlbwmon_tx" -- change to "mangle-iptmon_tx" to have full compliance with iptmon
-local TYPE_BYTES="ipt_bytes"
-local TYPE_PACKETS="ipt_packets"
-local TYPE_INSTANCE_PREFIX_RX="rx_"
-local TYPE_INSTANCE_PREFIX_TX="tx_"
+-- Load the necessary modules
+local io     = require "io"
+local ip_lib = require "luci.ip" -- Requires "luci-lib-ip" (~12kB installed)
+local jsonc  = require "luci.jsonc" -- Requires "luci-lib-jsonc" (~5.1kB installed)
+local ubus   = (require "ubus").connect()
 
-local function isempty(s)
-  return s == nil or s == ''
-end
+-- Save some often-used global functions as local variables for a slight speed
+-- boost.
+local pairs, ipairs = pairs, ipairs
 
+-- Helper function to execute a shell command and return its output
 local function exec(command)
-	local pp   = io.popen(command)
+	local pp, err = io.popen(command)
+    if not pp then
+        collectd.error("nlbw2collectd: Failed to execute command '" ..
+                       command .. "': " .. err)
+        return nil
+    end
+
 	local data = pp:read("*a")
 	pp:close()
 
 	return data
 end
 
-local function lookup(ip)
-    local client
-
-    -- First check the lease file for host name
---    local lease_file=luci.sys.exec("uci get dhcp.@dnsmasq[0].leasefile")
-    local lease_file=exec("uci get dhcp.@dnsmasq[0].leasefile")
-    lease_file = lease_file:gsub('[%c]', '')
-    command = "grep \"\\b" .. ip .. "\\b\" " .. lease_file .. " | awk '{print $4}'"
---    client=luci.sys.exec(command)
-    client=exec(command)
-    client = client:gsub('[%c]', '')
-
-    if isempty(client) then
-        -- Try with nslookup then
-        command = "nslookup " .. ip .. " | grep 'name = ' | sed -E 's/^.*name = ([a-zA-Z0-9-]+).*$/\\1/'"
---        client = luci.sys.exec(command)
-        client=exec(command)
-        client = client:gsub('[%c]', '')
-    end
-
-
-    if isempty(client) then
-        client = ip
-    end
-
-    if client == '*' then
-        client = ip
-    end
-
-    return client
+-- IPv6 addresses can be in various formats (hex character letter case, ::
+-- compression, leading zeros, etc.), so we'll normalize them here.
+local function normalize_ip(ip_str)
+    return ip_lib.new(ip_str):string()
 end
 
+-- Map IP addresses to hostnames by using the getHostHints ubus procedure.
+local ip_to_host = {}
+local function refresh_hosts()
+    local hosts = ubus:call("luci-rpc", "getHostHints", {})
 
-function read()
-    --collectd.log_info("read function called")
---    local json = luci.sys.exec("/usr/sbin/nlbw -c json -g ip")
+    for mac, data in pairs(hosts) do
+        local name = data.name
+
+        for _, ipv4 in ipairs(data.ipaddrs or {}) do
+            ipv4 = normalize_ip(ipv4)
+            ip_to_host[ipv4] = name
+        end
+        for _, ipv6 in ipairs(data.ip6addrs or {}) do
+            ipv6 = normalize_ip(ipv6)
+            ip_to_host[ipv6] = name
+        end
+    end
+end
+
+-- Function to find a hostname from an IP address
+local function get_hostname(ip)
+    ip = normalize_ip(ip)
+    local hostname = ip_to_host[ip]
+
+    if not hostname then
+        -- Refresh the list of hosts if the MAC is not found
+        refresh_hosts()
+        hostname = ip_to_host[ip]
+        if not hostname then
+            return ip
+        end
+    end
+
+    -- Extract only the hostname without domain
+    return hostname:match("^([^.]+)")
+end
+
+-- Fetch all the statistics
+local function read()
     local json = exec("/usr/sbin/nlbw -c json -g ip")
-    --collectd.log_info("exec function called")
-    local pjson = luci.jsonc.parse(json) 
-    --collectd.log_info("Json: " .. json)
+    local pjson = jsonc.parse(json)
+    local values = {}
 
+    -- Aggregate the values for each client
+    for _, value in ipairs(pjson.data) do
+        local ip = value[1]
+        local tx_bytes = value[3]
+        local tx_packets = value[4]
+        local rx_bytes = value[5]
+        local rx_packets = value[6]
 
-    for index, value in ipairs(pjson.data) do
-    
-    local client = ""
-    local ip = value[1]
-    --command = "nslookup " .. ip .. " | grep 'name = ' | sed -E 's/^.*name = ([a-zA-Z0-9-]+).*$/\\1/'"
-    --local client = exec(command)
-    local tx_bytes = value[3]
-    local tx_packets = value[4]
-    local rx_bytes = value[5]
-    local rx_packets = value[6]
-    local tx_bytes_modulo = tx_bytes % 2147483647 --workaround since we can not report to collectd more than 32bit integer
-    local rx_bytes_modulo = rx_bytes % 2147483647 --workaround since we can not report to collectd more than 32bit integer
+        local client = get_hostname(ip)
 
+        -- collectd only accepts a single value for each
+        -- plugin_instance/type_instance, but with IPv4 and IPv6, a single host
+        -- can have multiple IPs, so we'll need to sum them here.
+        local value = values[client] or {
+            tx_bytes = 0,
+            tx_packets = 0,
+            rx_bytes = 0,
+            rx_packets = 0
+        }
 
-    client = lookup(ip)
+        -- collectd can only handle signed 32-bit integers, so we'll wrap any
+        -- values greater than this.
+        value.tx_bytes   = (value.tx_bytes   + tx_bytes  ) % 0x7fffffff
+        value.rx_bytes   = (value.rx_bytes   + rx_bytes  ) % 0x7fffffff
+        value.tx_packets = (value.tx_packets + tx_packets) % 0x7fffffff
+        value.rx_packets = (value.rx_packets + rx_packets) % 0x7fffffff
 
-    --collectd.log_info("ip: " .. ip .. " , client: " .. client)
+        values[client] = value
+    end
 
-        tx_b = {
+    -- Send the values to collectd
+    for client, value in pairs(values) do
+        collectd.dispatch_values {
             host = HOSTNAME,
             plugin = PLUGIN,
             plugin_instance = PLUGIN_INSTANCE_TX,
             type = TYPE_BYTES,
-            type_instance =  TYPE_INSTANCE_PREFIX_TX .. client, 
-            values = {tx_bytes_modulo},
+            type_instance =  TYPE_INSTANCE_PREFIX_TX .. client,
+            values = { value.tx_bytes },
         }
-        collectd.dispatch_values(tx_b)
 
-        rx_b = {
+        collectd.dispatch_values {
             host = HOSTNAME,
             plugin = PLUGIN,
             plugin_instance = PLUGIN_INSTANCE_RX,
             type = TYPE_BYTES,
             type_instance =  TYPE_INSTANCE_PREFIX_RX .. client,
-            values = {rx_bytes_modulo},
+            values = { value.rx_bytes },
         }
-        collectd.dispatch_values(rx_b)
 
-
-
-        tx_p = {
+        collectd.dispatch_values {
             host = HOSTNAME,
             plugin = PLUGIN,
             plugin_instance = PLUGIN_INSTANCE_TX,
             type = TYPE_PACKETS,
             type_instance =  TYPE_INSTANCE_PREFIX_TX .. client,
-            values = {tx_packets},
+            values = { value.tx_packets },
         }
-        collectd.dispatch_values(tx_p)
 
-        rx_p = {
+        collectd.dispatch_values {
             host = HOSTNAME,
             plugin = PLUGIN,
             plugin_instance = PLUGIN_INSTANCE_RX,
             type = TYPE_PACKETS,
             type_instance =  TYPE_INSTANCE_PREFIX_RX .. client,
-            values = {rx_packets},
+            values = { value.rx_packets },
         }
-        collectd.dispatch_values(rx_p)
-
-
     end
-
-    return 0
 end
 
-collectd.register_read(read)     -- pass function as variable
+-- We'll catch any errors in the read function here so that they don't propagate
+-- into collectd.
+collectd.register_read(function()
+    local ok, err = pcall(read)
+    if not ok then
+        collectd.log_error("Error in read function: " .. tostring(err))
+    end
+    return 0
+end)


### PR DESCRIPTION
This commit adds support for dual-stack (IPv4 and IPv6) hosts by normalizing any IP addresses to a consistent format, and then summing the statistics for each host. This commit also makes the hostname resolution more robust by using the builtin `getHostHints` ubus procedure.

I've rewrote lots of the original code, so please let me know if there are any changes that you want me to make.

Also, I can't find any licences in this repository, so can you please add one? I'm okay with any open source licence, so pick whichever one you prefer.